### PR TITLE
remove syncMode from mutation examples

### DIFF
--- a/approaches/domain-driven-design/pattern1/README.md
+++ b/approaches/domain-driven-design/pattern1/README.md
@@ -148,7 +148,7 @@ Mutation with required `zipcode` property.
 
 ```graphql
 mutation m{
-  add_CustomerAccount(input: {customerId: "10001", firstName: "Jay", lastName: "Pipes"}, syncMode: ASYNC) {
+  add_CustomerAccount(input: {customerId: "10001", firstName: "Jay", lastName: "Pipes"}) {
       transaction {
         transactionId
       }

--- a/approaches/domain-driven-design/pattern2/README.md
+++ b/approaches/domain-driven-design/pattern2/README.md
@@ -130,10 +130,10 @@ In the `MyNodes` click the `CRMReadWriteNode` and navigate to `GraphQL Explorer`
 mutation m {
 
   add_CustomerAccount(id: "", input: {address: {zipcode: 95678}, customerId: "1001", firstName: "Vikrant", lastName: "Kahir"}, 
-aclInput: {acl: {principal: {nodes: "*"}, operations: READ}}, syncMode: ASYNC)
+aclInput: {acl: {principal: {nodes: "*"}, operations: READ}})
 
   add_CustomerProfile(input: {DMAbyZip: "95678", Psychographic: {goals: "quit smoking", habits: "smoking", pains: "back pain"}, customerId: "1001"}, 
-aclInput: {acl: {principal: {nodes: "*"}, operations: READ}}, syncMode: ASYNC)
+aclInput: {acl: {principal: {nodes: "*"}, operations: READ}})
 
 
 }
@@ -157,8 +157,8 @@ _id:&lt;?CustomerProfile>
 
 ```graphql
 mutation m @vendia_transaction {
-  update_CustomerAccount(id: "<?insert_id(CustomerAccount) here>", input: {address: {zipcode: 88888}}, syncMode: ASYNC)
-  update_CustomerProfile(id: "<?insert _id(CustomerProfile) here>", input: {DMAbyZip: "88888"}, syncMode: ASYNC)
+  update_CustomerAccount(id: "<?insert_id(CustomerAccount) here>", input: {address: {zipcode: 88888}})
+  update_CustomerProfile(id: "<?insert _id(CustomerProfile) here>", input: {DMAbyZip: "88888"})
 }
 
 ```
@@ -189,7 +189,7 @@ query listBlocks {
             {
               "mutations": [
                 "mutation m{update_CustomerAccount: updateSelf_CustomerAccount(id:\"xxxxxxxxxxxxxxxx\",input: {address: {zipcode: 88888}})
-                \nupdate_CustomerProfile: updateSelf_CustomerProfile(id:\"xxxxxxxxxxxxxxxx\",input: {DMAbyZip: \"88888\"}, syncMode: ASYNC)}"
+                \nupdate_CustomerProfile: updateSelf_CustomerProfile(id:\"xxxxxxxxxxxxxxxx\",input: {DMAbyZip: \"88888\")}"
 
 ```
 ## Clean Up

--- a/approaches/domain-driven-design/pattern3/README.md
+++ b/approaches/domain-driven-design/pattern3/README.md
@@ -67,7 +67,7 @@ Add the following mutation using the `GraphQL Explorer` of the **CRM** node..
 mutation m {
 
   put_CustomerAccount(id: "", input: {address: {zipcode: 95678}, customerId: "1001", firstName: "Jay", lastName: "Pipes"}, 
-aclInput: {acl: {principal: {nodes: "*"}, operations: READ}}, syncMode: ASYNC)
+aclInput: {acl: {principal: {nodes: "*"}, operations: READ}})
 
 
 }
@@ -81,7 +81,7 @@ Using the `Marketing` node. Add the following mutation using GraphQL explorer.
 mutation m {
 
   add_CustomerProfile(input: {DMAbyZip: "95678", Psychographic: {goals: "quit smoking", habits: "smoking", pains: "back pain"}, customerId: "1001"}, 
-aclInput: {acl: {principal: {nodes: "*"}, operations: READ}}, syncMode: ASYNC)
+aclInput: {acl: {principal: {nodes: "*"}, operations: READ}})
 
 }
 ```

--- a/demos/crm-sharing/console-experience/resources/jv1-add-contacts.gql
+++ b/demos/crm-sharing/console-experience/resources/jv1-add-contacts.gql
@@ -22,7 +22,6 @@ mutation createAccountContacts {
                 }
             ]
         },
-        syncMode: ASYNC,
         aclInput: {
             acl: [
                 # Implicit ACL for the data writer - not explicitly needed
@@ -60,7 +59,6 @@ mutation createAccountContacts {
                 }
             ]
         },
-        syncMode: ASYNC
         aclInput: {
             acl: [
                 # Implicit ACL for the data writer - not explicitly needed

--- a/demos/crm-sharing/console-experience/resources/jv2-add-contacts.gql
+++ b/demos/crm-sharing/console-experience/resources/jv2-add-contacts.gql
@@ -22,7 +22,6 @@ mutation createAccountContacts {
                 }
             ]
         },
-        syncMode: ASYNC,
         aclInput: {
             acl: [
                 # Implicit ACL for the data writer - not explicitly needed
@@ -60,7 +59,6 @@ mutation createAccountContacts {
                 }
             ]
         },
-        syncMode: ASYNC
         aclInput: {
             acl: [
                 # Implicit ACL for the data writer - not explicitly needed

--- a/demos/crm-sharing/postgres-to-salesforce/postgres/roles/postgres/tasks/main.yml
+++ b/demos/crm-sharing/postgres-to-salesforce/postgres/roles/postgres/tasks/main.yml
@@ -138,7 +138,6 @@
                   email: $email,
                   phone: $phone
                 },
-                syncMode: ASYNC,
                 aclInput: {
                   acl: [
                     { principal: { nodes: [ "salesforce" ]}, operations: [ READ ] }
@@ -276,7 +275,6 @@
                 email: $email,
                 phone: $phone
               },
-              syncMode: ASYNC,
               aclInput: {
                 acl: [
                   { principal: { nodes: [ "salesforce" ]}, operations: [ READ ] }
@@ -395,7 +393,7 @@
           mutation removeAccountContact(
             $_id: ID!
           ) {
-            remove_AccountContact(id: $_id, syncMode: ASYNC) {
+            remove_AccountContact(id: $_id) {
               transaction {
                 _id
               }

--- a/demos/finserv-and-insurance/simple-loan-marketplace/README.md
+++ b/demos/finserv-and-insurance/simple-loan-marketplace/README.md
@@ -214,7 +214,7 @@ You can add data using the GraphQL Explorer view from either node in the Uni.
     ```graphql
     mutation AddLoanPerformance {
       add_LoanPerformance(
-        input: { lastPaidInstallmentDate: "2022-04-01", loanIdentifier: "23456", monthlyReportingPeriod: "2022-05-01", servicerId: "54321", currentInterestRate: 2.75, currentUnpaidPrincipalBalance: 551000, loanDelinquencyStatus: current }, syncMode: ASYNC) {
+        input: { lastPaidInstallmentDate: "2022-04-01", loanIdentifier: "23456", monthlyReportingPeriod: "2022-05-01", servicerId: "54321", currentInterestRate: 2.75, currentUnpaidPrincipalBalance: 551000, loanDelinquencyStatus: current }) {
           transaction {
             transactionId
             _owner

--- a/demos/food-and-beverage/simple-supplier-distributor/README.md
+++ b/demos/food-and-beverage/simple-supplier-distributor/README.md
@@ -185,7 +185,7 @@ You can add data using the GraphQL Explorer view from either node in the Uni.
    ```graphql
    mutation AddProduct {
      add_Product(
-      input: {category: natural, description: "Organic", name: "Orange Juice", price: 3.99, sku: "00008", supplier: "Wild Harvest"}, syncMode: ASYNC) {
+      input: {category: natural, description: "Organic", name: "Orange Juice", price: 3.99, sku: "00008", supplier: "Wild Harvest"}) {
         transaction {
             transactionId
          }
@@ -254,7 +254,7 @@ You can update data using the GraphQL Explorer view from either node in the Uni.
    mutation UpdateProduct {
      update_Product(
       id: "017f273f-6f69-4adb-e73a-a140b3ccc28f"
-      input: {price: 3.49}, syncMode: ASYNC) {
+      input: {price: 3.49}) {
          transaction {
             transactionId
          }

--- a/demos/food-and-beverage/supplier-distributor-with-control/resources/deliveries.gql
+++ b/demos/food-and-beverage/supplier-distributor-with-control/resources/deliveries.gql
@@ -16,8 +16,7 @@ mutation AddDelivery {
                 {principal: {nodes: "DistributorNode"}, path: "actualDateTime", operations: [READ]},
                 {principal: {nodes: "DistributorNode"}, path: "status", operations: [READ]}
             ]
-        }, 
-        syncMode: ASYNC) {
+        }) {
             transaction {
                 _id
                 _owner

--- a/demos/food-and-beverage/supplier-distributor-with-control/resources/products.gql
+++ b/demos/food-and-beverage/supplier-distributor-with-control/resources/products.gql
@@ -18,8 +18,7 @@ mutation AddProductsWithACLs {
                 {principal: {nodes: "DistributorNode"}, path: "supplier", operations: [READ]},
                 {principal: {nodes: "DistributorNode"}, path: "category", operations: [READ]},
             ]
-        },
-        syncMode: ASYNC) {
+        }) {
         transaction {
             _id
             _owner
@@ -47,8 +46,7 @@ mutation AddProductsWithACLs {
                 {principal: {nodes: "DistributorNode"}, path: "supplier", operations: [READ]},
                 {principal: {nodes: "DistributorNode"}, path: "category", operations: [READ]}
             ]
-        }, 
-        syncMode: ASYNC) {
+        }) {
         transaction {
             _id
             _owner
@@ -76,8 +74,7 @@ mutation AddProductsWithACLs {
                 {principal: {nodes: "DistributorNode"}, path: "supplier", operations: [READ]},
                 {principal: {nodes: "DistributorNode"}, path: "category", operations: [READ]}
             ]
-        }, 
-        syncMode: ASYNC) {
+        }) {
         transaction {
             _id
             _owner
@@ -105,8 +102,7 @@ mutation AddProductsWithACLs {
                 {principal: {nodes: "DistributorNode"}, path: "supplier", operations: [READ]},
                 {principal: {nodes: "DistributorNode"}, path: "category", operations: [READ]},
             ]
-        },
-        syncMode: ASYNC) {
+        }) {
         transaction {
             _id
             _owner
@@ -134,8 +130,7 @@ mutation AddProductsWithACLs {
                 {principal: {nodes: "DistributorNode"}, path: "supplier", operations: [READ]},
                 {principal: {nodes: "DistributorNode"}, path: "category", operations: [READ]}
             ]
-        },
-        syncMode: ASYNC) {
+        }) {
         transaction {
             _id
             _owner
@@ -163,8 +158,7 @@ mutation AddProductsWithACLs {
                 {principal: {nodes: "DistributorNode"}, path: "supplier", operations: [READ]},
                 {principal: {nodes: "DistributorNode"}, path: "category", operations: [READ]}
             ]
-        },
-        syncMode: ASYNC) {
+        }) {
         transaction {
             _id
             _owner

--- a/demos/food-and-beverage/supplier-distributor-with-control/resources/purchase_orders.gql
+++ b/demos/food-and-beverage/supplier-distributor-with-control/resources/purchase_orders.gql
@@ -15,8 +15,7 @@ mutation AddPurchaseOrders {
                 {principal: {nodes: "SupplierNode"}, path: "dateIssued", operations: [READ]},
                 {principal: {nodes: "SupplierNode"}, path: "status", operations: [READ, WRITE]}
             ]
-        },
-        syncMode: ASYNC) {
+        }) {
         transaction {
             _id
             _owner
@@ -41,8 +40,7 @@ mutation AddPurchaseOrders {
                 {principal: {nodes: "SupplierNode"}, path: "dateIssued", operations: [READ]},
                 {principal: {nodes: "SupplierNode"}, path: "status", operations: [READ, WRITE]}
             ]
-        },
-        syncMode: ASYNC) {
+        }) {
         transaction {
             _id
             _owner
@@ -67,8 +65,7 @@ mutation AddPurchaseOrders {
                 {principal: {nodes: "SupplierNode"}, path: "dateIssued", operations: [READ]},
                 {principal: {nodes: "SupplierNode"}, path: "status", operations: [READ, WRITE]}
             ]
-        },
-        syncMode: ASYNC) {
+        }) {
         transaction{
             _id
             _owner

--- a/demos/travel-and-hospitality/alliance-ticket-sharing/resources/american-tickets.gql
+++ b/demos/travel-and-hospitality/alliance-ticket-sharing/resources/american-tickets.gql
@@ -126,8 +126,7 @@ mutation createTickets {
             acl: [
                 { principal: {nodes: ["AmericanNode"]}, operations: [ALL, UPDATE_ACL] },
             ]
-        },
-        syncMode: ASYNC) {
+        }) {
         transaction {
             _id
             _owner
@@ -275,8 +274,7 @@ mutation createTickets {
                 { principal: {nodes: ["IberiaNode"]}, path: "taxes", operations: [READ] },
                 { principal: {nodes: ["IberiaNode"]}, path: "fees", operations: [READ] }
             ]
-        },
-        syncMode: ASYNC){
+        }){
         transaction {
             _id
             _owner

--- a/demos/travel-and-hospitality/alliance-ticket-sharing/resources/iberia-tickets.gql
+++ b/demos/travel-and-hospitality/alliance-ticket-sharing/resources/iberia-tickets.gql
@@ -126,8 +126,7 @@ mutation createTickets {
             acl: [
                 { principal: {nodes: ["IberiaNode"]}, operations: [ALL, UPDATE_ACL] },
             ]
-        },
-        syncMode: ASYNC) {
+        }) {
         transaction {
             _id
             _owner
@@ -275,8 +274,7 @@ mutation createTickets {
                 { principal: {nodes: ["AmericanNode"]}, path: "taxes", operations: [READ] },
                 { principal: {nodes: ["AmericanNode"]}, path: "fees", operations: [READ] }
             ]
-        },
-        syncMode: ASYNC){
+        }){
         transaction {
             _id
             _owner

--- a/features/share/access-controls/data-access-controls/README.md
+++ b/features/share/access-controls/data-access-controls/README.md
@@ -102,8 +102,7 @@ mutation addProductWithACLs {
         {principal: {nodes: "DistributorNode"}, path: "supplier", operations: READ},
         {principal: {nodes: "DistributorNode"}, path: "price", operations: READ}    
       ]
-    }, 
-    syncMode: ASYNC) {
+    }) {
     transaction {
       _id
       _owner
@@ -148,8 +147,7 @@ mutation addProductWithACLs {
         {principal: {nodes: "DistributorNode"}, path: "supplier", operations: READ},
         {principal: {nodes: "DistributorNode"}, path: "price", operations: READ}    
       ]
-    }, 
-    syncMode: ASYNC) {
+    }) {
     transaction {
       _id
       _owner
@@ -181,8 +179,7 @@ mutation addProductWithACLs {
       acl: [
         {principal: {nodes: "DistributorNode"}, path: "*", operations: []},
       ]
-    },
-    syncMode: ASYNC) {
+    }) {
     transaction {
       _id
       _owner
@@ -350,7 +347,7 @@ The Supplier should be able to modify any field of any Product.
 Executing this mutation from the **SupplierNode** will succeed.  
 ```
 mutation updateCornTortillaPromoContent {
-  update_Product(id: "017eb396-e83c-83f1-9ae7-3e040b78de0f", input: {promotionalContent: "https://www.shaws.com/shop/product-details.109900162.html"}, syncMode: ASYNC) {
+  update_Product(id: "017eb396-e83c-83f1-9ae7-3e040b78de0f", input: {promotionalContent: "https://www.shaws.com/shop/product-details.109900162.html"}) {
     transaction {
       _id
       _owner
@@ -365,7 +362,7 @@ mutation updateCornTortillaPromoContent {
 As will executing this mutation from the **SupplierNode**.
 ```
 mutation updateCornTortillaPrice {
-  update_Product(id: "017eb396-e83c-83f1-9ae7-3e040b78de0f", input: {price: 3.99}, syncMode: ASYNC) {
+  update_Product(id: "017eb396-e83c-83f1-9ae7-3e040b78de0f", input: {price: 3.99}) {
     transaction {
       _id
       _owner
@@ -385,7 +382,7 @@ The same is not true of the Distributor. The Distributor can only modify the `pr
 Executing this mutation from the **DistributorNode** will succeed.
 ```
 mutation updateCornTortillaPromoContent {
-  update_Product(id: "017eb396-e83c-83f1-9ae7-3e040b78de0f", input: {promotionalContent: "https://www.shaws.com/shop/product-details.109900162.html"}, syncMode: ASYNC) {
+  update_Product(id: "017eb396-e83c-83f1-9ae7-3e040b78de0f", input: {promotionalContent: "https://www.shaws.com/shop/product-details.109900162.html"}) {
     transaction {
       _id
       _owner
@@ -400,7 +397,7 @@ mutation updateCornTortillaPromoContent {
 But executing this mutation from the **DistributorNode** will fail, as expected, because of the ACLs protecting the `price` field.
 ```
 mutation updateCornTortillaPrice {
-  update_Product(id: "017eb396-e83c-83f1-9ae7-3e040b78de0f", input: {price: 3.99}, syncMode: ASYNC) {
+  update_Product(id: "017eb396-e83c-83f1-9ae7-3e040b78de0f", input: {price: 3.99}) {
     transaction {
       _id
       _owner

--- a/features/share/graphql-enhancements/golang1.x/conditional-update.go
+++ b/features/share/graphql-enhancements/golang1.x/conditional-update.go
@@ -78,8 +78,7 @@ func main() {
 			}
 			condition: {
 				quantity: {ge: $shipQuantity}
-			},
-			syncMode: ASYNC) {
+			}) {
 				transaction {
 					transactionId
 				}

--- a/features/share/graphql-enhancements/node/transaction-mutation.cjs
+++ b/features/share/graphql-enhancements/node/transaction-mutation.cjs
@@ -107,8 +107,7 @@ async function setQuantity(thing1, thing2, thing3, ship) {
         }
         condition: {
           quantity: {ge: $shipQuantity}
-        },
-        syncMode: ASYNC) {
+        }) {
           transaction {
             transactionId
           }
@@ -122,8 +121,7 @@ async function setQuantity(thing1, thing2, thing3, ship) {
         }
         condition: {
           quantity: {ge: $shipQuantity}
-        },
-        syncMode: ASYNC) {
+        }) {
           transaction {
             transactionId
           }
@@ -137,8 +135,7 @@ async function setQuantity(thing1, thing2, thing3, ship) {
         }
         condition: {
           quantity: {ge: $shipQuantity}
-        },
-        syncMode: ASYNC) {
+        }) {
           transaction {
             transactionId
           }

--- a/features/share/graphql/golang1.x/mutation.go
+++ b/features/share/graphql/golang1.x/mutation.go
@@ -63,8 +63,7 @@ func main() {
 		  input: {
 			quantity: $quantity
 			lastUpdated: $lastUpdated
-		  },
-		  syncMode: ASYNC) {
+		  }) {
 		  transaction {
 			transactionId
 		  }

--- a/features/share/graphql/node/mutation.cjs
+++ b/features/share/graphql/node/mutation.cjs
@@ -76,7 +76,7 @@ async function setQuantity(itemId, quantity) {
 
   const mutation = gql`
     mutation updateInventory($id: ID!, $quantity: Int, $lastUpdated: String) {
-      update_Inventory(id: $id, input: {quantity: $quantity, lastUpdated: $lastUpdated}, syncMode: ASYNC) {
+      update_Inventory(id: $id, input: {quantity: $quantity, lastUpdated: $lastUpdated}) {
         transaction {
           transactionId
         }

--- a/features/share/graphql/python3/mutation.py
+++ b/features/share/graphql/python3/mutation.py
@@ -92,7 +92,7 @@ def set_quantity(itemid, quantity):
     query = gql(
         """
         mutation updateInventory($id: ID!, $quantity: Int, $lastupdated: String) {
-            update_Inventory(id: $id, input: {quantity: $quantity, lastUpdated: $lastupdated}, syncMode: ASYNC) {
+            update_Inventory(id: $id, input: {quantity: $quantity, lastUpdated: $lastupdated}) {
                 transaction {
                     transactionId
                 }

--- a/features/share/smart-contracts/src/GqlMutations.js
+++ b/features/share/smart-contracts/src/GqlMutations.js
@@ -3,7 +3,6 @@ export class GqlMutations {
       mutation AddLoan($input: Self_Loan_Input_!) {
         add_Loan(
           input: $input,
-          syncMode: ASYNC,
           aclInput: {
               acl: [
                   { principal: {nodes: "LenderNode"}, operations: [ALL, UPDATE_ACL] }
@@ -28,7 +27,6 @@ export class GqlMutations {
                 portfolioIdentifier: "AAAA1111",
                 portfolioName: "Loan Portfolio"
             }
-              syncMode: ASYNC
               aclInput: {
                   acl: [
                       { principal: { nodes: "ServicerNode" }, operations: [ALL, UPDATE_ACL] },
@@ -56,9 +54,7 @@ export class GqlMutations {
           inputQuery: $inputQuery,
           outputMutation: $outputMutation,
           resource: {uri: $resource}
-        }
-        syncMode: ASYNC
-      ) {
+        }) {
         transaction {
           _id
           _owner

--- a/integrations/datastores/dynamo-to-share/src/stream_to_uni/index.py
+++ b/integrations/datastores/dynamo-to-share/src/stream_to_uni/index.py
@@ -73,8 +73,7 @@ def add_to_share(
                     quantity: $quantity,
                     tags: $tags,
                     unitPrice: $unitPrice
-                },
-                syncMode: ASYNC) {
+                }) {
                 transaction {
                     transactionId
                 }
@@ -153,7 +152,7 @@ def remove_from_share(
         mutation removeItem(
             $_id: ID!
         ) {
-            remove_Inventory(id: $_id, syncMode: ASYNC) {
+            remove_Inventory(id: $_id) {
                 transaction {
                     transactionId
                 }
@@ -258,8 +257,7 @@ def update_in_share(
                     quantity: $quantity,
                     unitPrice: $unitPrice,
                     tags: $tags
-                },
-                syncMode: ASYNC) {
+                }) {
                 transaction {
                     transactionId
                 }

--- a/integrations/datastores/postgres-to-share/roles/postgres/tasks/main.yml
+++ b/integrations/datastores/postgres-to-share/roles/postgres/tasks/main.yml
@@ -135,8 +135,7 @@
                   itemNumber: $itemNumber,
                   quantity: $quantity,
                   lastUpdated: $lastUpdated
-                },
-                syncMode: ASYNC) {
+                }) {
                 transaction {
                   transactionId
                 }
@@ -270,8 +269,7 @@
                 itemNumber: $itemNumber,
                 quantity: $quantity,
                 lastUpdated: $lastUpdated
-              },
-              syncMode: ASYNC) {
+              }) {
               transaction {
                 transactionId
               }
@@ -388,7 +386,7 @@
           mutation removeItem(
             $_id: ID!
           ) {
-            remove_Inventory(id: $_id, syncMode: ASYNC) {
+            remove_Inventory(id: $_id) {
               transaction {
                 transactionId
               }

--- a/integrations/eventing/eventbridge-to-share/src/new_shipment/index.py
+++ b/integrations/eventing/eventbridge-to-share/src/new_shipment/index.py
@@ -108,8 +108,7 @@ def add_shipment(order_date, due_date,
                     consigneeEmail: $consigneeEmail,
                     consigneeSpecialInstructions: $consigneeSpecialInstructions,
                     purchaseOrder: $purchaseOrder
-                },
-                syncMode: ASYNC) {
+                }) {
                 transaction {
                     transactionId
                 }

--- a/integrations/eventing/kafka-to-share/roles/kafka/templates/consumer.j2
+++ b/integrations/eventing/kafka-to-share/roles/kafka/templates/consumer.j2
@@ -103,8 +103,7 @@ def add_shipment(order_date, due_date,
                     consigneeEmail: $consigneeEmail,
                     consigneeSpecialInstructions: $consigneeSpecialInstructions,
                     purchaseOrder: $purchaseOrder
-                }, 
-                syncMode: ASYNC) {
+                }) {
                 transaction {
                     transactionId
                 }

--- a/integrations/eventing/kinesis-to-share/src/new_shipment/index.py
+++ b/integrations/eventing/kinesis-to-share/src/new_shipment/index.py
@@ -110,8 +110,7 @@ def add_shipment(order_date, due_date,
                     consigneeEmail: $consigneeEmail,
                     consigneeSpecialInstructions: $consigneeSpecialInstructions,
                     purchaseOrder: $purchaseOrder
-                },
-                syncMode: ASYNC) {
+                }) {
                 transaction {
                     transactionId
                 }

--- a/integrations/eventing/share-to-azure-functions/README.md
+++ b/integrations/eventing/share-to-azure-functions/README.md
@@ -200,8 +200,7 @@ To create an Azure Function:
                 }
               ]
             }
-          }, 
-          syncMode: ASYNC) {
+          }) {
           transaction {
             _id
             _owner
@@ -297,7 +296,7 @@ configured Azure Function).
           id: "<PO_ID>",
           input: {
             expected: "2022-01-03T00:00:00Z"
-          }, syncMode: ASYNC) {
+          }) {
           transaction {
             _id
             _owner

--- a/integrations/files/csv-to-share/src/csv_processing/index.py
+++ b/integrations/files/csv-to-share/src/csv_processing/index.py
@@ -166,8 +166,7 @@ def post_to_share(csv_file):
                                     recommendedLocation: $recommended_location,
                                     bought: $bought,
                                     timestampAdded: $timestamp_added
-                                }, 
-                                syncMode: ASYNC) {
+                                }) {
                                 transaction {
                                     transactionId
                                 }

--- a/integrations/files/email-to-share/src/process_attachments/index.py
+++ b/integrations/files/email-to-share/src/process_attachments/index.py
@@ -180,8 +180,7 @@ def post_to_share(csv_file):
                                     consigneeEmail: $consigneeEmail,
                                     location: $location,
                                     goods: $goods
-                                },
-                                syncMode: ASYNC) {
+                                }) {
                                 transaction {
                                     transactionId
                                 }

--- a/integrations/files/sftp-to-share/src/csv_parser/index.py
+++ b/integrations/files/sftp-to-share/src/csv_parser/index.py
@@ -182,8 +182,7 @@ def post_to_share(csv_file):
                                     consigneeEmail: $consigneeEmail,
                                     location: $location,
                                     goods: $goods
-                                }, 
-                                syncMode: ASYNC) {
+                                }) {
                                 transaction {
                                     transactionId
                                 }

--- a/integrations/security/saml-example/create-and-work-with-uni.md
+++ b/integrations/security/saml-example/create-and-work-with-uni.md
@@ -75,7 +75,7 @@ We can issue a mutation to write data to our Uni using a similar curl command.
 curl ${GRAPHQL_URL} \
 -H 'Content-Type: application/json' \
 -H "Authorization: ${AUTHORIZATION}" \
---data-binary '{"query":"mutation newItem($itemName: String!, $itemNumber: String!, $quantity: Int!) {\n  add_InventoryItem(input: {itemName: $itemName, itemNumber: $itemNumber,  quantity: $quantity}, syncMode: ASYNC) {\n    transaction {\n      transactionId\n    }\n  }\n}","variables":{"itemName":"foo bar","itemNumber":"abc123","quantity":100}}' \
+--data-binary '{"query":"mutation newItem($itemName: String!, $itemNumber: String!, $quantity: Int!) {\n  add_InventoryItem(input: {itemName: $itemName, itemNumber: $itemNumber,  quantity: $quantity}) {\n    transaction {\n      transactionId\n    }\n  }\n}","variables":{"itemName":"foo bar","itemNumber":"abc123","quantity":100}}' \
 --compressed
 ```
 

--- a/workshops/food-and-beverage/optimized-distribution/README-Milestone4.md
+++ b/workshops/food-and-beverage/optimized-distribution/README-Milestone4.md
@@ -14,7 +14,7 @@ You will now create a purchase order using the GraphQL Explorer.
 
   ```
   mutation createPurchaseOrder {
-    add_PurchaseOrder(input: {dateIssued: "2022-01-26", quantity: "100", sku: "00001", totalPrice: 199}, syncMode: ASYNC) {
+    add_PurchaseOrder(input: {dateIssued: "2022-01-26", quantity: "100", sku: "00001", totalPrice: 199}) {
       transaction {
         _id
         _owner
@@ -30,7 +30,7 @@ You will now create a purchase order using the GraphQL Explorer.
 
   ```
   mutation createPurchaseOrder {
-    add_PurchaseOrder(input: {dateIssued: "2022-01-26", quantity: "40", sku: "00004", totalPrice: 30.8}, syncMode: ASYNC) {
+    add_PurchaseOrder(input: {dateIssued: "2022-01-26", quantity: "40", sku: "00004", totalPrice: 30.8}) {
       transaction {
         _id
         _owner
@@ -75,7 +75,7 @@ First, confirm the purchase orders submitted to the **DistributorNode** are in f
 
   ```
   mutation scheduleDelivery {
-    add_Delivery(input: {status: scheduled, expectedDateTime: "2022-01-28T12:00:00Z", purchaseOrders: [{purchaseOrderId: "017e9989-52dd-eaa0-7c58-43a39bfc8b9d"}, {purchaseOrderId: "017e994e-c2a3-0bac-cd67-d23d6af22680"}]}, syncMode: ASYNC) {
+    add_Delivery(input: {status: scheduled, expectedDateTime: "2022-01-28T12:00:00Z", purchaseOrders: [{purchaseOrderId: "017e9989-52dd-eaa0-7c58-43a39bfc8b9d"}, {purchaseOrderId: "017e994e-c2a3-0bac-cd67-d23d6af22680"}]}) {
       transaction {
         _id
         _owner

--- a/workshops/food-and-beverage/optimized-distribution/README-Milestone5.md
+++ b/workshops/food-and-beverage/optimized-distribution/README-Milestone5.md
@@ -17,8 +17,7 @@ mutation enableBlockNotificationEmails {
   updateVendia_Settings(
     input: {
       blockReportEmails: ["you@domain.com"]
-    }, 
-    syncMode: ASYNC) {
+    }) {
     transaction {
       _id
       _owner

--- a/workshops/food-and-beverage/optimized-distribution/README-Milestone6.md
+++ b/workshops/food-and-beverage/optimized-distribution/README-Milestone6.md
@@ -117,8 +117,7 @@ func main() {
 			price: $price
 			promotionalContent: $promotionalContent
 			supplier: $supplier
-		  },
-		  syncMode: ASYNC) {
+		  }) {
 		  transaction {
 			transactionId
 		  }
@@ -239,8 +238,7 @@ func main() {
 			quantity: $quantity,
 			dateIssued: $dateIssued,
 			totalPrice: $totalPrice
-		  },
-		  syncMode: ASYNC) {
+		  }) {
 		  transaction {
 			transactionId
 		  }


### PR DESCRIPTION
Remove `syncMode` from mutations. With the new WAL feature, we changed the default from `NODE_LEDGERED` to `NODE_COMMITTED` which is a "faster" consistency mode. We consider `syncMode` to be an advanced feature that most customers will not use. Therefore, we will remove this from the mutations to simplify the examples.